### PR TITLE
SnipeIT Overhaul; Update {`Jamf`, `Requests`, `Makefile`, `Dependencies`} & more…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,14 @@ clean:
 # Flush the cache and any tests
 flush:
 	@/bin/bash -c 'if compgen -G "$$TMPDIR/rego_*" > /dev/null; then rm -rf $$TMPDIR/rego_*; fi'
+
+# Replace every matching line in $(SRC_DIR) with NEW_COPYRIGHT
+SRC_DIR := pkg
+NEW_COPYRIGHT := ":Copyright: (c) 2025 by Gemini Space Station, LLC, see AUTHORS for more info"  # your replacement string
+
+.PHONY: update-copyright
+update-copyright:
+	@echo "Updating copyright lines to $(NEW_COPYRIGHT)…"
+	@find $(SRC_DIR) -type f -print0 | \
+	  perl -0 -pi -e 's/^:Copyright: \(c\) 202[0-9].*/$(NEW_COPYRIGHT)/mg'
+	@echo "Done."

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ flush:
 
 # Replace every matching line in $(SRC_DIR) with NEW_COPYRIGHT
 SRC_DIR := pkg
-NEW_COPYRIGHT := ":Copyright: (c) 2025 by Gemini Space Station, LLC, see AUTHORS for more info"  # your replacement string
+NEW_COPYRIGHT  := :Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 
 .PHONY: update-copyright
 update-copyright:
 	@echo "Updating copyright lines to $(NEW_COPYRIGHT)…"
 	@find $(SRC_DIR) -type f -print0 | \
-	  perl -0 -pi -e 's/^:Copyright: \(c\) 202[0-9].*/$(NEW_COPYRIGHT)/mg'
+	  xargs -0 perl -pi -e 's/^:Copyright: \(c\) 202[0-9].*/'"$(NEW_COPYRIGHT)"'/mg'
 	@echo "Done."

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 require (
 	github.com/go-ldap/ldap/v3 v3.4.11
 	golang.org/x/crypto v0.38.0
+	golang.org/x/net v0.40.0
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/text v0.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.40.0 h1:79Xs7wF06Gbdcg4kdCCIQArK11Z1hr5POQ6+fIYHNuY=
+golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
 golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
 golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=

--- a/pkg/active_directory/active_directory.go
+++ b/pkg/active_directory/active_directory.go
@@ -4,7 +4,7 @@
 This package initializes all the methods which interact with {Active Directory/LDAP}:
 - https://docs.microsoft.com/en-us/windows/win32/ad/active-directory-schema
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/active_directory/entities.go
+++ b/pkg/active_directory/entities.go
@@ -4,7 +4,7 @@
 This package contains various structs for handling Active Directory objects like Users, Groups, etc.
 - https://learn.microsoft.com/en-us/windows/win32/adschema/classes-all
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/active_directory/groups.go
+++ b/pkg/active_directory/groups.go
@@ -3,7 +3,7 @@
 
 This file contains functions for group-related operations in Active Directory.
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/active_directory/query.go
+++ b/pkg/active_directory/query.go
@@ -5,7 +5,7 @@ This package initializes all the methods for queries to filter {Active Directory
 - https://learn.microsoft.com/en-us/windows/win32/adsi/search-filter-syntax
 - https://theitbros.com/ldap-query-examples-active-directory/
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/active_directory/users.go
+++ b/pkg/active_directory/users.go
@@ -3,7 +3,7 @@
 
 This file contains functions for user-related operations in Active Directory.
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/atlassian/atlassian.go
+++ b/pkg/atlassian/atlassian.go
@@ -15,7 +15,7 @@ This package initializes all the methods for functions which interact with the A
 * Cloud Admin
 - https://developer.atlassian.com/cloud/admin/rest-apis/
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/atlassian/entities.go
+++ b/pkg/atlassian/entities.go
@@ -3,7 +3,7 @@
 
 This package contains many structs for handling responses from the Atlassian APIs:
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/atlassian/organizations.go
+++ b/pkg/atlassian/organizations.go
@@ -6,7 +6,7 @@ This package initializes all the methods for functions which interact with the O
 * Organizations REST API
 - https://developer.atlassian.com/cloud/admin/organization/rest/intro/#uri
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/atlassian/user_provisioning.go
+++ b/pkg/atlassian/user_provisioning.go
@@ -6,7 +6,7 @@ This package initializes all the methods for functions which interact with the O
 * User Provisioning REST API (SCIM)
 - https://developer.atlassian.com/cloud/admin/user-provisioning/rest/intro/#uri
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/activities.go
+++ b/pkg/backupify/activities.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with Backupify's Activities:
 {Exports, Restores, Backups}
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/backupify.go
+++ b/pkg/backupify/backupify.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Datto's Backupify WebUI:
 https://www.backupify.com/
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/entities.go
+++ b/pkg/backupify/entities.go
@@ -3,7 +3,7 @@
 
 This package contains many structs for handling payloads / responses from Backupify's WebUI:
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/exports.go
+++ b/pkg/backupify/exports.go
@@ -6,7 +6,7 @@ https://{node-url}.backupify.com/{customerID}/{service}/export
 
 * Currently only supports GoogleDrive exports
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/snapshots.go
+++ b/pkg/backupify/snapshots.go
@@ -6,7 +6,7 @@ https://{node-url}.backupify.com/{customerID}/{service}/serviceSnaps
 
 * Currently only supports GoogleDrive exports
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/backupify/users.go
+++ b/pkg/backupify/users.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with Datto's Backupify WebUI:
 https://www.backupify.com/
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/common/auth/auth.go
+++ b/pkg/common/auth/auth.go
@@ -3,7 +3,7 @@
 
 This package initializes methods for functions which need special authentication to interact with APIs:
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/common/requests/error_handling.go
+++ b/pkg/common/requests/error_handling.go
@@ -2,10 +2,14 @@
 package requests
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
+
+	"golang.org/x/net/html"
 )
 
 // RequestError represents an API request error.
@@ -36,6 +40,8 @@ func (c *Client) handleErrorResponse(resp *http.Response, body []byte) *RequestE
 	switch {
 	case strings.Contains(contentType, JSON):
 		c.parseJSONError(body, reqError)
+	case strings.Contains(contentType, HTML):
+		c.parseHTMLError(body, reqError)
 	case strings.Contains(contentType, Plain):
 		reqError.Message = string(body)
 	default:
@@ -69,4 +75,65 @@ func (c *Client) parseJSONError(body []byte, reqError *RequestError) {
 	if reqError.Message == "" {
 		reqError.Message = "Unknown JSON error response"
 	}
+}
+
+func (c *Client) parseHTMLError(body []byte, reqError *RequestError) {
+	doc, err := html.Parse(bytes.NewReader(body))
+	if err != nil {
+		reqError.Message = http.StatusText(reqError.StatusCode)
+		return
+	}
+
+	blockTags := map[string]bool{
+		"title": true, "h1": true, "h2": true, "h3": true,
+		"p": true, "li": true, "div": true, "section": true,
+	}
+
+	var segments []string
+	var collectText func(*html.Node) string
+	collectText = func(n *html.Node) string {
+		if n.Type == html.TextNode {
+			return strings.TrimSpace(n.Data)
+		}
+		if n.Type == html.ElementNode && (n.Data == "script" || n.Data == "style") {
+			return ""
+		}
+		var parts []string
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if t := collectText(c); t != "" {
+				parts = append(parts, t)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && blockTags[n.Data] {
+			if txt := collectText(n); txt != "" {
+				segments = append(segments, txt)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	if len(segments) == 0 {
+		reqError.Message = http.StatusText(reqError.StatusCode)
+		return
+	}
+
+	msg := strings.Join(segments, " | ")
+
+	// ▸ 1) remove any spaces *before* punctuation
+	reSpaceBeforePunct := regexp.MustCompile(`\s+([.,;:!?])`)
+	msg = reSpaceBeforePunct.ReplaceAllString(msg, `$1`)
+
+	// ▸ 2) collapse runs of spaces into a single space
+	reMultiSpace := regexp.MustCompile(`\s{2,}`)
+	msg = reMultiSpace.ReplaceAllString(msg, " ")
+
+	reqError.Message = msg
 }

--- a/pkg/common/requests/requests.go
+++ b/pkg/common/requests/requests.go
@@ -108,6 +108,11 @@ func NewClient(options ...interface{}) *Client {
 }
 
 // UpdateHeaders changes the headers for the HTTP client
+func (c *Client) UpdateAcceptType(contentType string) {
+	c.Headers["Accept"] = contentType
+}
+
+// UpdateHeaders changes the headers for the HTTP client
 func (c *Client) UpdateContentType(contentType string) {
 	c.Headers["Content-Type"] = contentType
 }

--- a/pkg/google/admin.go
+++ b/pkg/google/admin.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Google Admin API:
 https://developers.google.com/admin-sdk/reference-overview
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/api.go
+++ b/pkg/google/api.go
@@ -4,7 +4,7 @@
 This package contains all of the allowed scopes for the Google Workspace API:
 https://developers.google.com/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/devices.go
+++ b/pkg/google/devices.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with Devices from the Google Admin API:
 https://developers.google.com/admin-sdk/directory/reference/rest/v1/chromeosdevices
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/drive.go
+++ b/pkg/google/drive.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Google Drive API:
 https://developers.google.com/drive/api/v3/reference/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/entities.go
+++ b/pkg/google/entities.go
@@ -3,7 +3,7 @@
 
 This package contains many structs for handling responses from the Google API:
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/google.go
+++ b/pkg/google/google.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Google Workspace API:
 https://developers.google.com/workspace
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/permissions.go
+++ b/pkg/google/permissions.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Google Drive API for Permissions:
 https://developers.google.com/drive/api/reference/rest/v3/permissions/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/sheets.go
+++ b/pkg/google/sheets.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Google Sheets API:
 https://developers.google.com/sheets/api/reference/rest
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/google/users.go
+++ b/pkg/google/users.go
@@ -4,7 +4,7 @@
 This package implements logic related to the `Users` resource of the Google Admin SDK API:
 https://developers.google.com/admin-sdk/directory/reference/rest/v1/users
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/atlassian/atlassian_test.go
+++ b/pkg/internal/tests/atlassian/atlassian_test.go
@@ -4,7 +4,7 @@
 This package contains tests functions which interact with the Atlassian API:
 https://developers.google.com/admin-sdk/reference-overview
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/google/admin_test.go
+++ b/pkg/internal/tests/google/admin_test.go
@@ -4,7 +4,7 @@
 This package contains tests functions which interact with the Google Admin SDK API:
 https://developers.google.com/admin-sdk/reference-overview
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/google/api_test.go
+++ b/pkg/internal/tests/google/api_test.go
@@ -4,7 +4,7 @@
 This package tests functions which generate and organize the Google API
 https://developers.google.com/workspace
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/google/google_test.go
+++ b/pkg/internal/tests/google/google_test.go
@@ -4,7 +4,7 @@
 This package runs tests for functions which interact with the Google Workspace API:
 https://developers.google.com/workspace
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/okta/applications_test.go
+++ b/pkg/internal/tests/okta/applications_test.go
@@ -4,7 +4,7 @@
 This package tests functions related to the Okta Applications API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/#tag/Application
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/okta/devices_test.go
+++ b/pkg/internal/tests/okta/devices_test.go
@@ -4,7 +4,7 @@
 This package tests functions related to the Okta Devices API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/okta/okta_test.go
+++ b/pkg/internal/tests/okta/okta_test.go
@@ -4,7 +4,7 @@
 This package runs tests for functions which interact with the Okta API:
 https://developer.okta.com/docs/api/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/okta/roles_test.go
+++ b/pkg/internal/tests/okta/roles_test.go
@@ -4,7 +4,7 @@
 This package tests functions related to the Okta Roles API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Role/#tag/Role
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/internal/tests/okta/users_test.go
+++ b/pkg/internal/tests/okta/users_test.go
@@ -4,7 +4,7 @@
 This package tests functions related to the Okta Users API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/admin.go
+++ b/pkg/jamf/admin.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/classic_osxconfigurationprofiles.go
+++ b/pkg/jamf/classic_osxconfigurationprofiles.go
@@ -22,25 +22,37 @@ var (
 	ConfigurationProfiles = fmt.Sprintf("%s/osxconfigurationprofiles", "%s") // /osxconfigurationprofiles
 )
 
+// ProfilesClient for chaining methods
+type ProfilesClient struct {
+	client *Client
+}
+
+// Entry point for web-related operations
+func (c *Client) Profiles() *ProfilesClient {
+	return &ProfilesClient{
+		client: c,
+	}
+}
+
 /*
  * # List All Configuration Profiles
  * /osxconfigurationprofiles
  * - https://developer.jamf.com/jamf-pro/reference/findosxconfigurationprofiles
  */
-func (c *Client) ListAllConfigurationProfiles() (*OSXConfigurationProfiles, error) {
-	url := c.BuildClassicURL(ConfigurationProfiles)
+func (pc *ProfilesClient) ListAllConfigurationProfiles() (*OSXConfigurationProfiles, error) {
+	url := pc.client.BuildClassicURL(ConfigurationProfiles)
 
 	var cache OSXConfigurationProfiles
-	if c.GetCache(url, &cache) {
+	if pc.client.GetCache(url, &cache) {
 		return &cache, nil
 	}
 
-	osxCP, err := do[OSXConfigurationProfiles](c, "GET", url, nil, nil)
+	osxCP, err := do[OSXConfigurationProfiles](pc.client, "GET", url, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.SetCache(url, osxCP, 5*time.Minute)
+	pc.client.SetCache(url, osxCP, 5*time.Minute)
 	return &osxCP, nil
 }
 
@@ -49,20 +61,20 @@ func (c *Client) ListAllConfigurationProfiles() (*OSXConfigurationProfiles, erro
  * /osxconfigurationprofiles/id/{id}
  * - https://developer.jamf.com/jamf-pro/reference/findosxconfigurationprofiles
  */
-func (c *Client) GetConfigurationProfileDetails(id string) (*OSXConfigurationProfile, error) {
-	url := c.BuildClassicURL(ConfigurationProfiles, "id", id)
+func (pc *ProfilesClient) GetConfigurationProfileDetails(id string) (*OSXConfigurationProfile, error) {
+	url := pc.client.BuildClassicURL(ConfigurationProfiles, "id", id)
 
 	var cache OSXConfigurationProfile
-	if c.GetCache(url, &cache) {
+	if pc.client.GetCache(url, &cache) {
 		return &cache, nil
 	}
 
-	osxCP, err := do[OSXConfigurationProfile](c, "GET", url, nil, nil)
+	osxCP, err := do[OSXConfigurationProfile](pc.client, "GET", url, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.SetCache(url, osxCP, 5*time.Minute)
+	pc.client.SetCache(url, osxCP, 5*time.Minute)
 	return &osxCP, nil
 }
 
@@ -71,19 +83,19 @@ func (c *Client) GetConfigurationProfileDetails(id string) (*OSXConfigurationPro
  * /osxconfigurationprofiles/id/{id}
  * - https://developer.jamf.com/jamf-pro/reference/updateosxconfigurationprofilebyid
  */
-func (c *Client) UpdateConfigurationProfile(id string) (*OSXConfigurationProfile, error) {
-	url := c.BuildClassicURL(ConfigurationProfiles, "id", id)
+func (pc *ProfilesClient) UpdateConfigurationProfile(id string) (*OSXConfigurationProfile, error) {
+	url := pc.client.BuildClassicURL(ConfigurationProfiles, "id", id)
 
 	var cache OSXConfigurationProfile
-	if c.GetCache(url, &cache) {
+	if pc.client.GetCache(url, &cache) {
 		return &cache, nil
 	}
 
-	osxCP, err := do[*OSXConfigurationProfile](c, "PUT", url, nil, nil)
+	osxCP, err := do[*OSXConfigurationProfile](pc.client, "PUT", url, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	c.SetCache(url, osxCP, 5*time.Minute)
+	pc.client.SetCache(url, osxCP, 5*time.Minute)
 	return osxCP, nil
 }

--- a/pkg/jamf/classic_osxconfigurationprofiles.go
+++ b/pkg/jamf/classic_osxconfigurationprofiles.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/classic_usergroups.go
+++ b/pkg/jamf/classic_usergroups.go
@@ -1,0 +1,125 @@
+/*
+# Jamf - User Groups
+
+This package initializes all the methods for functions which interact with the Jamf API:
+- https://developer.jamf.com/jamf-pro/reference/classic-api
+- https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
+
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
+:License: See the LICENSE file for details
+:Author: Anthony Dardano <anthony.dardano@gemini.com>
+*/
+
+// pkg/jamf/classic_usergroups.go
+package jamf
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+)
+
+var (
+	ClassicUserGroups = fmt.Sprintf("%s/usergroups", "%s") // /usergroups
+)
+
+// UserClient for chaining methods
+type UserGroupsClient struct {
+	client *Client
+}
+
+// Entry point for web-related operations
+func (c *Client) UserGroups() *UserGroupsClient {
+	return &UserGroupsClient{
+		client: c,
+	}
+}
+
+/*
+ * # List All User Groups
+ * /usergroups
+ * - https://developer.jamf.com/jamf-pro/reference/findusergroups
+ */
+func (ugc *UserGroupsClient) ListAllUserGroups() (*UserGroups, error) {
+	url := ugc.client.BuildClassicURL(ClassicUserGroups)
+
+	var cache UserGroups
+	if ugc.client.GetCache(url, &cache) {
+		return &cache, nil
+	}
+
+	userGroups, err := do[UserGroups](ugc.client, "GET", url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ugc.client.SetCache(url, userGroups, 5*time.Minute)
+	return &userGroups, nil
+}
+
+/*
+ * # Get User Group by ID
+ * /usergroups/id/{id}
+ * - https://developer.jamf.com/jamf-pro/reference/findusergroupsbyid
+ */
+func (ugc *UserGroupsClient) GetUserGroup(id string) (*UserGroup, error) {
+	url := ugc.client.BuildClassicURL(ClassicUserGroups, "id", id)
+
+	var cache UserGroup
+	if ugc.client.GetCache(url, &cache) {
+		return &cache, nil
+	}
+
+	userGroup, err := do[UserGroup](ugc.client, "GET", url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ugc.client.SetCache(url, userGroup, 5*time.Minute)
+	return &userGroup, nil
+}
+
+/*
+ * # Get User Group by Name
+ * /usergroups/name/{name}
+ * - https://developer.jamf.com/jamf-pro/reference/findusergroupsbyname
+ */
+func (ugc *UserGroupsClient) GetUserGroupByName(name string) (*UserGroup, error) {
+	url := ugc.client.BuildClassicURL(ClassicUserGroups, "name", name)
+
+	var cache UserGroup
+	if ugc.client.GetCache(url, &cache) {
+		return &cache, nil
+	}
+
+	userGroup, err := do[UserGroup](ugc.client, "GET", url, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ugc.client.SetCache(url, userGroup, 5*time.Minute)
+	return &userGroup, nil
+}
+
+/*
+ * # Create User Group
+ * /usergroups/id/{id}
+ * - https://developer.jamf.com/jamf-pro/reference/createusergroupsbyid
+ */
+func (ugc *UserGroupsClient) CreateUserGroup(userGroup *UserGroup) error {
+	url := ugc.client.BuildClassicURL(ClassicUserGroups, "id", -1)
+
+	userGroupBody := struct {
+		XMLName xml.Name `xml:"user_group"`
+		*UserGroup
+	}{
+		UserGroup: userGroup,
+	}
+
+	_, err := do[any](ugc.client, "POST", url, nil, userGroupBody)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/jamf/classic_users.go
+++ b/pkg/jamf/classic_users.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/devices.go
+++ b/pkg/jamf/devices.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/entities.go
+++ b/pkg/jamf/entities.go
@@ -545,25 +545,49 @@ type User struct {
 	EnableCustomPhotoURL bool                  `json:"enable_custom_photo_url,omitempty" xml:"enable_custom_photo_url,omitempty"` // Indicates if custom photo URL is enabled.
 	ExtensionAttributes  []*ExtensionAttribute `json:"extension_attributes,omitempty" xml:"extension_attributes,omitempty"`       // Extension attributes
 	FullName             string                `json:"full_name,omitempty" xml:"full_name,omitempty"`                             // Full name of the user.
-	LDAPServer           []*JamfProperty       `json:"ldap_server,omitempty" xml:"ldap_server,omitempty"`                         // LDAP server information.
-	Links                []*UserLink           `json:"links,omitempty" xml:"links,omitempty"`                                     // Links associated with the user.
+	LDAPServer           *JamfProperty         `json:"ldap_server,omitempty" xml:"ldap_server,omitempty"`                         // LDAP server information.
+	Links                *UserLinks            `json:"links,omitempty" xml:"links,omitempty"`                                     // Links associated with the user.
 	ManagedAppleID       string                `json:"managed_apple_id,omitempty" xml:"managed_apple_id,omitempty"`               // Managed Apple ID.
 	PhoneNumber          string                `json:"phone_number,omitempty" xml:"phone_number,omitempty"`                       // Phone number of the user.
 	Position             string                `json:"position,omitempty" xml:"position,omitempty"`                               // Position of the user.
-	Sites                []*Site               `json:"sites,omitempty" xml:"sites,omitempty"`                                     // Sites
-	UserGroups           []*UserGroup          `json:"user_groups,omitempty" xml:"user_groups,omitempty"`                         // Groups the user belongs to.
+	Sites                []*Site               `json:"sites,omitempty" xml:"sites>site,omitempty"`                                // Sites
+	UserGroups           UserGroups            `json:"user_groups,omitempty" xml:"user_groups,omitempty"`                         // Groups the user belongs to.
 }
 
 // UserLink represents a link associated with a user.
-type UserLink struct {
-	Computer          []*Computer `json:"computer,omitempty" xml:"computer,omitempty"`                         // Computer information.
-	TotalVPPCodeCount int         `json:"total_vpp_code_count,omitempty" xml:"total_vpp_code_count,omitempty"` // Total VPP code count.
+type UserLinks struct {
+	Computer          []*JamfProperty `json:"computers,omitempty" xml:"computers,omitempty"`                       // Computer information.
+	Peripherals       []*JamfProperty `json:"peripherals,omitempty" xml:"peripherals,omitempty"`                   // Peripherals information.
+	MobileDevices     []*JamfProperty `json:"mobile_devices,omitempty" xml:"mobile_devices,omitempty"`             // Mobile Devices information.
+	TotalVPPCodeCount int             `json:"total_vpp_code_count,omitempty" xml:"total_vpp_code_count,omitempty"` // Total VPP code count.
 }
 
-// UserGroup represents a group that a user belongs to.
+// UserGroups represents a list of user groups in the Jamf Pro API.
+type UserGroups struct {
+	Size   int           `json:"size" xml:"size"`              // Size of the user groups list.
+	Groups *[]*UserGroup `json:"user_groups" xml:"user_group"` // List of JSS User Groups
+}
+
+// UserGroup represents a group that a user belongs to (Smart/Static).
 type UserGroup struct {
 	*JamfProperty
-	IsSmart bool `json:"is_smart,omitempty" xml:"is_smart,omitempty"` // Indicates if the group is a smart group.
+	IsSmart          bool         `json:"is_smart" xml:"is_smart"`                                           // Indicates if the group is a smart group.
+	IsNotifyOnChange bool         `json:"is_notify_on_change,omitempty" xml:"is_notify_on_change,omitempty"` // Indicates if notifications are enabled for changes.
+	Site             *Site        `json:"site,omitempty" xml:"site,omitempty"`                               // Site information of the group.
+	Criteria         []*Criterion `json:"criteria,omitempty" xml:"criteria>criterion,omitempty"`             // Criteria for the smart group.
+	Size             int          `xml:"users>size,omitempty"`                                               // Member size of the group.
+	Users            []*User      `json:"users,omitempty" xml:"users>user,omitempty"`                        // List of users in the group.
+}
+
+// Criterion represents a criterion for a smart group or search.
+type Criterion struct {
+	Name               string `json:"name,omitempty" xml:"name,omitempty"`                   // Name of the criterion.
+	Priority           int    `json:"priority,omitempty" xml:"priority,omitempty"`           // Priority of the criterion.
+	AndOr              string `json:"and_or,omitempty" xml:"and_or,omitempty"`               // Logical operator (AND/OR).
+	SearchType         string `json:"search_type,omitempty" xml:"search_type,omitempty"`     // Type of search operation. (e.g., "like", "is", "is not").
+	Value              string `json:"value,omitempty" xml:"value,omitempty"`                 // Value for the criterion.
+	OpeningParenthesis bool   `json:"opening_paren,omitempty" xml:"opening_paren,omitempty"` // Indicates if there is an opening parenthesis.
+	ClosingParenthesis bool   `json:"closing_paren,omitempty" xml:"closing_paren,omitempty"` // Indicates if there is a closing parenthesis.
 }
 
 // END OF JAMF USER STRUCTS

--- a/pkg/jamf/jamf.go
+++ b/pkg/jamf/jamf.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/management.go
+++ b/pkg/jamf/management.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/jamf/version.go
+++ b/pkg/jamf/version.go
@@ -5,7 +5,7 @@ This package initializes all the methods for functions which interact with the J
 - https://developer.jamf.com/jamf-pro/reference/classic-api
 - https://developer.jamf.com/jamf-pro/reference/jamf-pro-api
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/lenel_s2/entities.go
+++ b/pkg/lenel_s2/entities.go
@@ -30,7 +30,7 @@ type NetboxResponse[E any] struct {
 
 type Response[E any] struct {
 	APIError int    `xml:"APIERROR"`         // APIError holds API-level error codes if present (e.g. "1", "2", etc.)
-	Code     string `xml:"CODE"`             // // CODE is the command response code ("SUCCESS" or "FAIL")
+	Code     string `xml:"CODE"`             // CODE is the command response code ("SUCCESS" or "FAIL")
 	Details  *E     `xml:"DETAILS"`          // Can be an object of any type
 	Error    string `xml:"ERRMSG,omitempty"` // Error stores a human-readable error message from command-level failures.
 }

--- a/pkg/lenel_s2/lenel_s2.go
+++ b/pkg/lenel_s2/lenel_s2.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Lenel S2 API:
 https://developer.okta.com/docs/api/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/lenel_s2/lenel_s2.go
+++ b/pkg/lenel_s2/lenel_s2.go
@@ -1,7 +1,7 @@
 /*
 # Lenel S2
 
-This package initializes all the methods for functions which interact with the Okta API:
+This package initializes all the methods for functions which interact with the Lenel S2 API:
 https://developer.okta.com/docs/api/
 
 :Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
@@ -23,7 +23,6 @@ import (
 	"github.com/gemini-oss/rego/pkg/common/cache"
 	"github.com/gemini-oss/rego/pkg/common/config"
 	"github.com/gemini-oss/rego/pkg/common/log"
-	_ "github.com/gemini-oss/rego/pkg/common/ratelimit"
 	"github.com/gemini-oss/rego/pkg/common/requests"
 )
 
@@ -207,11 +206,6 @@ func NewClient(baseURL string, verbosity int) *Client {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	// https://developer.okta.com/docs/reference/rl-best-practices/
-	// httpClient.RateLimiter = ratelimit.NewRateLimiter()
-	// httpClient.RateLimiter.ResetHeaders = true
-	// httpClient.RateLimiter.Log.Verbosity = verbosity
 
 	return &Client{
 		BaseURL: url,

--- a/pkg/okta/applications.go
+++ b/pkg/okta/applications.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Applications API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Application/#tag/Application
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/devices.go
+++ b/pkg/okta/devices.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Devices API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/entities.go
+++ b/pkg/okta/entities.go
@@ -3,7 +3,7 @@
 
 This package contains many structs for handling responses from the Okta API:
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/groups.go
+++ b/pkg/okta/groups.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Groups API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/okta.go
+++ b/pkg/okta/okta.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Okta API:
 https://developer.okta.com/docs/api/
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/roles.go
+++ b/pkg/okta/roles.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Roles API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Role/#tag/Role
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/user_factors.go
+++ b/pkg/okta/user_factors.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Users API for Factors:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/UserFactor/
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/okta/users.go
+++ b/pkg/okta/users.go
@@ -4,7 +4,7 @@
 This package contains all the methods to interact with the Okta Users API:
 https://developer.okta.com/docs/api/openapi/okta-management/management/tag/User/#tag/User
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/orchestrators/orchestrators.go
+++ b/pkg/orchestrators/orchestrators.go
@@ -3,7 +3,7 @@
 
 This package contains some functions involving practical examples of multi-service orchestration.
 
-:Copyright: (c) 2024 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/slack/bot.go
+++ b/pkg/slack/bot.go
@@ -4,7 +4,7 @@
 This package initializes the methods for functions which handle a typical Slack bot with the Slack Web API:
 https://api.slack.com/web
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/slack/entities.go
+++ b/pkg/slack/entities.go
@@ -3,7 +3,7 @@
 
 This package contains many structs for handling responses from the Slack Web API:
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC, see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the Slack Web API:
 https://api.slack.com/web
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/slack/users.go
+++ b/pkg/slack/users.go
@@ -4,7 +4,7 @@
 This package initializes the methods for functions which handle a user methods with the Slack Web API:
 https://api.slack.com/web
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/accessories.go
+++ b/pkg/snipeit/accessories.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Accessories endpoints:
 https://snipe-it.readme.io/reference/accessories
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/assets.go
+++ b/pkg/snipeit/assets.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Assets endpoints:
 https://snipe-it.readme.io/reference/hardware-list
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/categories.go
+++ b/pkg/snipeit/categories.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Categories endpoints:
 https://snipe-it.readme.io/reference/categories
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/entities.go
+++ b/pkg/snipeit/entities.go
@@ -4,7 +4,7 @@
 This package initializes all the structs for the SnipeIT API:
 https://snipe-it.readme.io/reference/api-overview
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/entities.go
+++ b/pkg/snipeit/entities.go
@@ -13,9 +13,11 @@ https://snipe-it.readme.io/reference/api-overview
 package snipeit
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/gemini-oss/rego/pkg/common/cache"
@@ -57,8 +59,15 @@ func (pl PaginatedList[E]) Map() map[any]*E {
 		switch entity := any(item).(type) {
 		case *Hardware[any]:
 			result[entity.Serial] = item
-		case *User:
-			result[entity.Email] = item
+		case *User[UserGET]:
+			switch entity.Email {
+			case nil:
+				result[entity.Username] = item
+			default:
+				result[(*(*(*entity).UserBase).Email)] = item
+			}
+		case *License[LicenseGET]:
+			result[(*(*(*(*entity).LicenseBase).SnipeIT).Record).Name] = item
 		default:
 			// Fallback to the `ID` field if available
 			value := reflect.ValueOf(item).Elem()
@@ -139,13 +148,15 @@ type PPPD struct {
 	CreatedAt      *string `json:"created_at,omitempty"`      // Time when the item was created.
 	UpdatedAt      *string `json:"updated_at,omitempty"`      // Time when the item was last updated.
 	DeletedAt      *string `json:"deleted_at,omitempty"`      // Time when the item was deleted.
-	CategoryID     *uint32 `json:"category_id,omitempty"`     // {MODEL,LICENSE} Category ID
+	AssetID        *uint32 `json:"asset_id,omitempty"`        // {LICENSE_SEAT} Asset ID
+	CategoryID     *uint32 `json:"category_id,omitempty"`     // {MODEL,LICENSES} Category ID
 	CompanyID      *uint32 `json:"company_id,omitempty"`      // {HARDWARE,LICENSE} Company ID
-	DepartmentID   *uint32 `json:"department_id,omitempty"`   // Department ID
+	DepartmentID   *uint32 `json:"department_id,omitempty"`   // {LICENSE,USER} Department ID
 	DepreciationID *uint32 `json:"depreciation_id,omitempty"` // {MODEL} Depreciation ID
 	FieldsetID     *uint32 `json:"fieldset_id,omitempty"`     // {MODEL} Fieldset ID
 	LocationID     *uint32 `json:"location_id,omitempty"`     // Location ID
-	ManufacturerID *uint32 `json:"manufacturer_id,omitempty"` // {MODEL,LICENSE} Manufacturer ID
+	ManagerID      *uint32 `json:"manager_id,omitempty"`      // {USER} Manager ID
+	ManufacturerID *uint32 `json:"manufacturer_id,omitempty"` // {LICENSE,MODEL} Manufacturer ID
 	ModelID        *uint32 `json:"model_id,omitempty"`        // Model ID
 	ParentID       *uint32 `json:"parent_id,omitempty"`       // {Location} Parent ID
 	RTDLocationID  *uint32 `json:"rtd_location_id,omitempty"` // RTD Location ID
@@ -182,10 +193,10 @@ type HardwareBase struct {
 
 type HardwareGET struct {
 	GET          `json:",inline"`
-	Archived     string    `json:"archived,omitempty"`      // Whether the hardware item is archived (string on GET, bool on PPPD)
-	AssignedTo   *User     `json:"assigned_to,omitempty"`   // User to whom the hardware item is assigned. (object on GET, string on POST)
-	PurchaseCost string    `json:"purchase_cost,omitempty"` // Purchase cost of the hardware item. (string on GET, float on POST)
-	PurchaseDate *DateInfo `json:"purchase_date,omitempty"` // Purchase date of the hardware item. (object on GET, string on PPPD)
+	Archived     string         `json:"archived,omitempty"`      // Whether the hardware item is archived (string on GET, bool on PPPD)
+	AssignedTo   *User[UserGET] `json:"assigned_to,omitempty"`   // User to whom the hardware item is assigned. (object on GET, string on POST)
+	PurchaseCost string         `json:"purchase_cost,omitempty"` // Purchase cost of the hardware item. (string on GET, float on POST)
+	PurchaseDate *DateInfo      `json:"purchase_date,omitempty"` // Purchase date of the hardware item. (object on GET, string on PPPD)
 }
 
 type HardwarePOST struct {
@@ -352,43 +363,75 @@ type Location struct {
 
 // ### Users
 // -------------------------------------------------------------------------
-type UserList = PaginatedList[User]
+type UserList = PaginatedList[User[UserGET]]
 
-type User struct {
-	*SnipeIT           `json:",inline"`
-	Activated          bool              `json:"activated"`                     // Specifies if the user is active or not
-	Address            string            `json:"address,omitempty"`             // Address of the user
-	AssetsCount        int64             `json:"assets_count,omitempty"`        // Number of assets associated with the user
-	AutoassignLicenses bool              `json:"autoassign_licenses,omitempty"` // Specifies if the licenses are automatically assigned to the user
-	Avatar             string            `json:"avatar,omitempty"`              // URL of the user's avatar
-	City               string            `json:"city,omitempty"`                // City of the user
-	ConsumablesCount   int64             `json:"consumables_count,omitempty"`   // Count of consumables associated with the user
-	Country            string            `json:"country,omitempty"`             // Country of the user
-	CreatedBy          *DateInfo         `json:"created_by,omitempty"`          // Who created the user
-	Email              string            `json:"email,omitempty"`               // Email of the user
-	EmployeeNum        string            `json:"employee_num,omitempty"`        // Employee number of the user
-	EndDate            *DateInfo         `json:"end_date,omitempty"`            // End date of the user
-	FirstName          string            `json:"first_name,omitempty"`          // First name of the user
-	Groups             interface{}       `json:"groups,omitempty"`              // Groups that the user belongs to
-	ID                 int64             `json:"id,omitempty"`                  // ID of the user
-	Jobtitle           string            `json:"jobtitle,omitempty"`            // Job title of the user
-	LastLogin          string            `json:"last_login,omitempty"`          // Last login time of the user
-	LastName           string            `json:"last_name,omitempty"`           // Last name of the user
-	LdapImport         bool              `json:"ldap_import,omitempty"`         // Specifies if the user is imported from LDAP
-	Locale             string            `json:"locale,omitempty"`              // Locale of the user
-	Name               string            `json:"name,omitempty"`                // Full name of the user
-	Notes              string            `json:"notes,omitempty"`               // Notes associated with the user
-	Permissions        map[string]string `json:"permissions,omitempty"`         // Permissions of the user
-	Phone              string            `json:"phone,omitempty"`               // Phone number of the user
-	Remote             bool              `json:"remote,omitempty"`              // Specifies if the user is remote
-	StartDate          *DateInfo         `json:"start_date,omitempty"`          // Start date of the user
-	State              string            `json:"state,omitempty"`               // State of the user
-	TwoFactorEnrolled  bool              `json:"two_factor_enrolled,omitempty"` // Specifies if the user has enrolled for two factor authentication
-	TwoFactorOptin     bool              `json:"two_factor_optin,omitempty"`    // Specifies if the user has opted for two factor authentication
-	Username           string            `json:"username,omitempty"`            // Username of the user
-	Vip                bool              `json:"vip,omitempty"`                 // Specifies if the user is a VIP
-	Website            string            `json:"website,omitempty"`             // Website of the user
-	Zip                string            `json:"zip,omitempty"`                 // Zip code of the user
+type UserBase struct {
+	*SnipeIT              `json:",inline"`
+	Avatar                string           `json:"avatar,omitempty"`                  // URL of the user's avatar
+	Name                  string           `json:"name,omitempty"`                    // Full name of the user
+	FirstName             string           `json:"first_name"`                        // First name of the user
+	LastName              string           `json:"last_name,omitempty"`               // Last name of the user
+	Username              string           `json:"username"`                          // Username of the user
+	Remote                bool             `json:"remote,omitempty"`                  // Specifies if the user is remote
+	Locale                *string          `json:"locale,omitempty"`                  // Locale of the user
+	EmployeeNum           *string          `json:"employee_num,omitempty"`            // Employee number of the user
+	JobTitle              *string          `json:"jobtitle,omitempty"`                // Job title of the user
+	VIP                   BoolInt          `json:"vip,omitempty"`                     // Specifies if the user is a VIP
+	Phone                 *string          `json:"phone,omitempty"`                   // Phone number of the user
+	Website               *string          `json:"website,omitempty"`                 // Website of the user
+	Address               *string          `json:"address,omitempty"`                 // Address of the user
+	City                  *string          `json:"city,omitempty"`                    // City of the user
+	State                 *string          `json:"state,omitempty"`                   // State of the user
+	Country               *string          `json:"country,omitempty"`                 // Country of the user
+	Zip                   *string          `json:"zip,omitempty"`                     // Zip code of the user
+	Email                 *string          `json:"email,omitempty"`                   // Email of the user
+	Notes                 *string          `json:"notes,omitempty"`                   // Notes associated with the user
+	Permissions           map[string]uint8 `json:"permissions,omitempty"`             // Permissions of the user
+	Activated             bool             `json:"activated"`                         // Specifies if the user is active or not
+	AutoAssignLicenses    bool             `json:"autoassign_licenses,omitempty"`     // Specifies if the licenses are automatically assigned to the user
+	LDAPImport            bool             `json:"ldap_import,omitempty"`             // Specifies if the user is imported from LDAP
+	TwoFactorEnrolled     bool             `json:"two_factor_enrolled,omitempty"`     // Specifies if the user has enrolled for two factor authentication
+	TwoFactorOptIn        bool             `json:"two_factor_optin,omitempty"`        // Specifies if the user has opted for two factor authentication
+	LastLogin             *DateInfo        `json:"last_login,omitempty"`              // Last login time of the user
+	AssetsCount           uint32           `json:"assets_count,omitempty"`            // Number of assets associated with the user
+	ConsumablesCount      uint32           `json:"consumables_count,omitempty"`       // Count of consumables associated with the user
+	ManagesUsersCount     uint32           `json:"manages_users_count,omitempty"`     // Number of users managed by the user
+	ManagesLocationsCount uint32           `json:"manages_locations_count,omitempty"` // Number of locations managed by the user
+	CreatedBy             *Record          `json:"created_by,omitempty"`              // Who created the user
+}
+
+type User[M any] struct {
+	*UserBase `json:",inline"`
+	Method    M `json:",inline"`
+}
+
+func (u User[M]) MarshalJSON() ([]byte, error) {
+	return generics.MarshalGeneric[User[M], M](&u)
+}
+
+func (u *User[M]) UnmarshalJSON(data []byte) error {
+	user, err := generics.UnmarshalGeneric[User[M], M](data)
+	if err != nil {
+		return err
+	}
+
+	*u = *user
+	return nil
+}
+
+type UserGET struct {
+	GET       `json:",inline"`
+	StartDate *DateInfo `json:"start_date,omitempty"` // Start date of the user
+	EndDate   *DateInfo `json:"end_date,omitempty"`   // End date of the user
+}
+
+type UserPOST struct {
+	PPPD                 `json:",inline"`
+	Password             string     `json:"password"`              // Password of the user
+	PasswordConfirmation string     `json:"password_confirmation"` // Password confirmation of the user
+	Groups               []uint32   `json:"groups,omitempty"`      // Groups associated with the user
+	StartDate            *Timestamp `json:"start_date,omitempty"`  // Start date of the user
+	EndDate              *Timestamp `json:"end_date,omitempty"`    // End date of the user
 }
 
 // END OF USER STRUCTS
@@ -413,6 +456,20 @@ type ModelBase struct {
 type Model[M any] struct {
 	*ModelBase `json:",inline"`
 	Method     M `json:",inline"`
+}
+
+func (m Model[M]) MarshalJSON() ([]byte, error) {
+	return generics.MarshalGeneric[Model[M], M](&m)
+}
+
+func (m *Model[M]) UnmarshalJSON(data []byte) error {
+	model, err := generics.UnmarshalGeneric[Model[M], M](data)
+	if err != nil {
+		return err
+	}
+
+	*m = *model
+	return nil
 }
 
 // END OF MODELS STRUCTS
@@ -569,6 +626,125 @@ func (b LicenseBuilder) Reassignable(v bool) LicenseBuilder {
 
 // END OF LICENSE STRUCTS
 // -------------------------------------------------------------------------
+
+// ### License Seats
+// -------------------------------------------------------------------------
+// Source: https://snipe-it.readme.io/reference/licenses
+type SeatList = PaginatedList[Seat[SeatGET]]
+
+type SeatBase struct {
+	*SnipeIT `json:",inline"`
+}
+
+type SeatGET struct {
+	GET          `json:",inline"`
+	LicenseID    int `json:"license_id,omitempty"`
+	AssignedUser struct {
+		*Record
+		Department *Record `json:"department,omitempty"`
+	} `json:"assigned_user,omitempty"`
+	AssignedAsset   string `json:"assigned_asset,omitempty"`
+	Reassignable    bool   `json:"reassignable,omitempty"`
+	UserCanCheckout bool   `json:"user_can_checkout,omitempty"`
+}
+
+type SeatPOST struct {
+	PPPD         `json:",inline"`
+	AssignedTo   *uint32 `json:"assigned_to"`            // The User ID to assign the license to
+	Notes        string  `json:"notes,omitempty"`        // Notes about the seat (Exists in the response, but not used for body)
+	Reassignable bool    `json:"reassignable,omitempty"` // Whether the license is reassignable
+}
+
+/*
+MarshalJSON → send `Notes` out as "note"
+*/
+func (s SeatPOST) MarshalJSON() ([]byte, error) {
+	type alias SeatPOST
+	return json.Marshal(&struct {
+		alias
+		Note string `json:"note,omitempty"`
+	}{
+		alias: alias(s),
+		Note:  s.Notes,
+	})
+}
+
+/*
+UnmarshalJSON → accept either "notes" or "note" from server
+*/
+func (s *SeatPOST) UnmarshalJSON(data []byte) error {
+	type alias SeatPOST
+	aux := &struct {
+		alias
+		Note     *string         `json:"note"`
+		Notes    *string         `json:"notes"`
+		Assigned json.RawMessage `json:"assigned_to"`
+	}{}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	*s = SeatPOST(aux.alias)
+
+	// Handle "notes" field → accept "notes" or "note"
+	// Standardize into "notes" for Rego
+	switch {
+	case aux.Notes != nil:
+		s.Notes = *aux.Notes
+	case aux.Note != nil:
+		s.Notes = *aux.Note
+	}
+
+	// Handle `assigned_to`
+	if len(aux.Assigned) > 0 && string(aux.Assigned) != "null" {
+		// 1) try as JSON number
+		var id uint32
+		if err := json.Unmarshal(aux.Assigned, &id); err == nil {
+			s.AssignedTo = &id
+			return nil
+		}
+
+		// 2) try as quoted string
+		var str string
+		if err := json.Unmarshal(aux.Assigned, &str); err == nil {
+			v, err := strconv.ParseUint(str, 10, 32)
+			if err != nil {
+				return fmt.Errorf("assigned_to: %q is not a valid uint32", str)
+			}
+			u := uint32(v)
+			s.AssignedTo = &u
+			return nil
+		}
+
+		return fmt.Errorf("assigned_to has unsupported JSON type: %s", aux.Assigned)
+	}
+
+	return nil
+}
+
+type Seat[M any] struct {
+	*SeatBase `json:",inline"`
+	Method    M `json:",inline"`
+}
+
+func (s Seat[M]) MarshalJSON() ([]byte, error) {
+	return generics.MarshalGeneric[Seat[M], M](&s)
+}
+
+func (s *Seat[M]) UnmarshalJSON(data []byte) error {
+	seat, err := generics.UnmarshalGeneric[Seat[M], M](data)
+	if err != nil {
+		return err
+	}
+
+	*s = *seat
+	return nil
+}
+
+// END OF LICENSE SEAT STRUCTS
+// -------------------------------------------------------------------------
+
 // ### Common Asset types
 // -------------------------------------------------------------------------
 // Record represents an id:name pairing for many types of records in Snipe-IT.
@@ -578,6 +754,7 @@ type Record struct {
 }
 
 const (
+	snipeDate = "2006-01-02"
 	snipeTime = "2006-01-02 15:04:05"
 	iso8601   = "2006-01-02T15:04:05.000000Z"
 )
@@ -609,22 +786,50 @@ func (ts *Timestamp) UnmarshalJSON(b []byte) error {
 
 // parseDate attempts to parse a date string in ISO 8601 format first, then falls back to MySQL DATETIME format.
 func (ts *Timestamp) ParseDate(dateStr string) error {
-	t, err := time.Parse(iso8601, dateStr)
-	if err != nil {
-		t, err = time.Parse(snipeTime, dateStr)
-		if err != nil {
-			return err
-		}
+	// Try ISO 8601
+	if t, err := time.Parse(iso8601, dateStr); err == nil {
+		ts.Time = t
+		return nil
 	}
-
-	ts.Time = t
-	return nil
+	// Try snipeTime
+	if t, err := time.Parse(snipeTime, dateStr); err == nil {
+		ts.Time = t
+		return nil
+	}
+	// Try date-only fallback
+	if t, err := time.Parse(snipeDate, dateStr); err == nil {
+		ts.Time = t
+		return nil
+	}
+	return fmt.Errorf("unable to parse date string: %s", dateStr)
 }
 
 // DateInfo represents a date and its formatted representation.
 type DateInfo struct {
 	Date      string `json:"datetime,omitempty"`  // The date in yyyy-mm-dd format.
 	Formatted string `json:"formatted,omitempty"` // The formatted date.
+}
+
+func (d *DateInfo) UnmarshalJSON(b []byte) error {
+	var aux struct {
+		DateTime  string `json:"datetime"`
+		Date      string `json:"date"`
+		Formatted string `json:"formatted"`
+	}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	// Prefer "datetime" if present, else fall back to "date"
+	if aux.DateTime != "" {
+		d.Date = aux.DateTime
+	} else {
+		d.Date = aux.Date
+	}
+
+	d.Formatted = aux.Formatted
+	return nil
 }
 
 // StatusLabel represents the status label of a hardware item.
@@ -642,6 +847,32 @@ type AvailableActions struct {
 	Delete   bool `json:"delete,omitempty"`   // Whether delete action is available.
 	Restore  bool `json:"restore,omitempty"`  // Whether restore action is available.
 	Update   bool `json:"update,omitempty"`   // Whether update action is available.
+}
+
+// BoolInt encodes a bool as 0/1 and decodes either form (0/1 or true/false).
+type BoolInt bool
+
+func (b BoolInt) MarshalJSON() ([]byte, error) {
+	// outbound payload: 1 for true, 0 for false
+	if b {
+		return json.Marshal(1)
+	}
+	return json.Marshal(0)
+}
+
+func (b *BoolInt) UnmarshalJSON(data []byte) error {
+	// accept: 1, 0, "1", "0", true, false
+	switch string(bytes.TrimSpace(data)) {
+	case "1", `"1"`, "true":
+		*b = true
+	case "0", `"0"`, "false":
+		*b = false
+	case "null": // allow nullable field
+		*b = false
+	default:
+		return fmt.Errorf("BoolInt: expected 0/1/true/false, got %s", data)
+	}
+	return nil
 }
 
 // END OF COMMON ASSET TYPES

--- a/pkg/snipeit/licenses.go
+++ b/pkg/snipeit/licenses.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Licenses endpoints:
 https://snipe-it.readme.io/reference/licenses
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/locations.go
+++ b/pkg/snipeit/locations.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Locations endpoints:
 https://snipe-it.readme.io/reference/locations
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/snipeit.go
+++ b/pkg/snipeit/snipeit.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT API:
 https://snipe-it.readme.io/reference/api-overview
 
-:Copyright: (c) 2023 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/users.go
+++ b/pkg/snipeit/users.go
@@ -4,7 +4,7 @@
 This package initializes all the methods for functions which interact with the SnipeIT Users endpoints:
 https://snipe-it.readme.io/reference/users
 
-:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:Copyright: (c) 2025 by Gemini Software Services, LLC., see AUTHORS for more info
 :License: See the LICENSE file for details
 :Author: Anthony Dardano <anthony.dardano@gemini.com>
 */

--- a/pkg/snipeit/users.go
+++ b/pkg/snipeit/users.go
@@ -1,0 +1,168 @@
+/*
+# SnipeIT - Users
+
+This package initializes all the methods for functions which interact with the SnipeIT Users endpoints:
+https://snipe-it.readme.io/reference/users
+
+:Copyright: (c) 2025 by Gemini Space Station, LLC., see AUTHORS for more info
+:License: See the LICENSE file for details
+:Author: Anthony Dardano <anthony.dardano@gemini.com>
+*/
+
+// pkg/snipeit/users.go
+package snipeit
+
+import (
+	"time"
+)
+
+// UserClient for chaining methods
+type UserClient struct {
+	*Client
+}
+
+// Entry point for asset-related operations
+func (c *Client) Users() *UserClient {
+	uc := &UserClient{
+		Client: c,
+	}
+
+	return uc
+}
+
+/*
+ * Query Parameters for Users
+ */
+type UserQuery struct {
+	Search           string     `url:"search,omitempty"`            // Search for an user by string
+	Limit            int        `url:"limit,omitempty"`             // Specify the number of results you wish to return. Defaults to 50
+	Offset           int        `url:"offset,omitempty"`            // Specify the number of results to skip before starting to return items. Defaults to 0
+	Sort             string     `url:"sort,omitempty"`              // Sort the results by the specified column. Defaults to "created_at"
+	Order            string     `url:"order,omitempty"`             // Sort the results in the specified order ("asc" or "desc"). Defaults to "desc"
+	FirstName        string     `url:"first_name,omitempty"`        // First name of the user
+	LastName         string     `url:"last_name,omitempty"`         // Last name of the user
+	Username         string     `url:"username,omitempty"`          // Username of the user
+	Email            string     `url:"email,omitempty"`             // Email address of the user
+	EmployeeNumber   string     `url:"employee_numb,omitempty"`     // Employee number of the user
+	State            string     `url:"state,omitempty"`             // State of the user (active, inactive, etc.)
+	Zip              string     `url:"zip,omitempty"`               // Zip code of the user
+	Country          string     `url:"country,omitempty"`           // Country of the user
+	GroupID          uint32     `url:"group_id,omitempty"`          // ID of the group the user belongs to
+	DepartmentID     uint32     `url:"department_id,omitempty"`     // ID of the department the user belongs to
+	CompanyID        uint32     `url:"company_id,omitempty"`        // ID of the company the user belongs to
+	LocationID       uint32     `url:"location_id,omitempty"`       // ID of the location the user belongs to
+	Deleted          bool       `url:"deleted,omitempty"`           // Set to true to return deleted users
+	All              bool       `url:"all,omitempty"`               // Set to true to return all users, including deleted ones
+	LDAPImport       bool       `url:"ldap_import,omitempty"`       // Set to true to return only users imported from LDAP
+	AssetsCount      uint32     `url:"assets_count,omitempty"`      // Set to true to return only users with assets
+	LicensesCount    uint32     `url:"licenses_count,omitempty"`    // Number of checked out licenses for the user
+	AccessoriesCount uint32     `url:"accessories_count,omitempty"` // Number of checked out accessories for the user
+	ConsumablesCount uint32     `url:"consumables_count,omitempty"` // Number of checked out consumables for the user
+	Remote           bool       `url:"remote,omitempty"`            // Whether the user is marked as a remote worker or not (should be 0 or 1)
+	VIP              bool       `url:"vip,omitempty"`               // Whether the user is marked as a VIP or not (should be 0 or 1)
+	StartDate        *Timestamp `url:"start_date,omitempty"`        // Start date for the user
+	EndDate          *Timestamp `url:"end_date,omitempty"`          // End date for the user
+}
+
+// ### UserQuery implements QueryInterface
+// ---------------------------------------------------------------------
+func (q *UserQuery) Copy() QueryInterface {
+	return &UserQuery{
+		Search:           q.Search,
+		Limit:            q.Limit,
+		Offset:           q.Offset,
+		Sort:             q.Sort,
+		Order:            q.Order,
+		FirstName:        q.FirstName,
+		LastName:         q.LastName,
+		Username:         q.Username,
+		Email:            q.Email,
+		EmployeeNumber:   q.EmployeeNumber,
+		State:            q.State,
+		Zip:              q.Zip,
+		Country:          q.Country,
+		GroupID:          q.GroupID,
+		DepartmentID:     q.DepartmentID,
+		CompanyID:        q.CompanyID,
+		LocationID:       q.LocationID,
+		Deleted:          q.Deleted,
+		All:              q.All,
+		LDAPImport:       q.LDAPImport,
+		AssetsCount:      q.AssetsCount,
+		LicensesCount:    q.LicensesCount,
+		AccessoriesCount: q.AccessoriesCount,
+		ConsumablesCount: q.ConsumablesCount,
+		Remote:           q.Remote,
+		VIP:              q.VIP,
+		StartDate:        q.StartDate,
+		EndDate:          q.EndDate,
+	}
+}
+
+func (q *UserQuery) GetLimit() int {
+	return q.Limit
+}
+
+func (q *UserQuery) SetLimit(limit int) {
+	q.Limit = limit
+}
+
+func (q *UserQuery) GetOffset() int {
+	return q.Offset
+}
+
+func (q *UserQuery) SetOffset(offset int) {
+	q.Offset = offset
+}
+
+// END OF QUERYINTERFACE METHODS
+//---------------------------------------------------------------------
+
+/*
+ * List all Users in Snipe-IT
+ * /api/v1/users
+ * - https://snipe-it.readme.io/reference/users
+ */
+func (c *UserClient) GetAllUsers() (*UserList, error) {
+	url := c.BuildURL(Users)
+
+	q := UserQuery{
+		Limit:  500,
+		Offset: 0,
+	}
+
+	var cache UserList
+	if c.GetCache(url, &cache) {
+		return &cache, nil
+	}
+
+	users, err := doConcurrent[UserList](c.Client, "GET", url, &q, nil)
+	if err != nil {
+		c.Log.Fatalf("Error fetching license list: %v", err)
+	}
+
+	c.SetCache(url, users, 5*time.Minute)
+	return users, nil
+}
+
+/*
+ * # Get an user in Snipe-IT by ID
+ * /api/v1/users/{id}
+ * - https://snipe-it.readme.io/reference/usersid
+ */
+func (c *UserClient) GetUser(id uint32) (*User[UserGET], error) {
+	url := c.BuildURL(Users, id)
+
+	var cache User[UserGET]
+	if c.GetCache(url, &cache) {
+		return &cache, nil
+	}
+
+	user, err := do[User[UserGET]](c.Client, "GET", url, nil, nil)
+	if err != nil {
+		c.Log.Fatalf("Error getting user: %v", err)
+	}
+
+	c.SetCache(url, user, 5*time.Minute)
+	return &user, nil
+}


### PR DESCRIPTION
{Makefile}
- Add `update-copyright` target that scans `$(SRC_DIR)` and rewrites all legacy `:Copyright:` lines to a target string.

{Dependencies}
- `golang.org/x/net` → **v0.40.0**

{Requests}
- `handleErrorResponse()` now detects **HTML** error responses and delegates to `parseHTMLError()`, which strips scripts/styles, flattens block text, normalises whitespace and punctuation, and sets a concise `RequestError.Message`.
- New `parseHTMLError()` helper with robust DOM traversal using `golang.org/x/net/html` and regex clean-ups.
- Introduce `UpdateAcceptType()` to mutate the `Accept` header independently of `Content-Type`.
- Default error path now returns “unsupported content type” for unknown payloads.

{Jamf}
- Improve chainable sub-clients (Classic): `Profiles()`, `Users()`, `UserGroups()`
- `BuildURL()` / `BuildClassicURL()` now set dual-priority `Accept` headers (`JSON, XML` vs `XML, JSON`), correct `Content-Type`, and body format.
- Generic `do[T]` adds XML unmarshalling fallback when the client’s `Content-Type` is XML.
- Entity refresh:
  - Replace slice pointers (`[]*JamfProperty`) with struct aggregates (`*UserLinks`, `UserGroups`), add smart-group details (`Criterion`), and collapse `LDAPServer`/`Links` to single pointers.
  - `UserGroups` now carries size & members; `UserLink` split into separate collections for computers, peripherals, and mobile devices.

{SnipeIT}
- **License Seat management**
  - New generics: `Seat[SeatGET|SeatPOST]`, `SeatList`, and builder API `LicenseClient.Checkout(licenseID, seatID).ToUser(userID | .ToAsset(assetID))` plus `Checkin()`.
  - Helpers `Seats()`, `Seat()`, `Checkout()`, `Checkin()` expose full seat lifecycle.
- User/model generics overhaul: `User[UserGET]`, `Model[ModelGET]`, etc., with auto marshal/unmarshal helpers; introduces `BoolInt` (encodes `true/false` ↔ `1/0`).
- `PaginatedList.Map()` expanded: chooses `Username` when `Email` is nil; supports license seat keying.
- Timestamp parsing now accepts ISO-8601, MySQL `DATETIME`, and date-only (`YYYY-MM-DD`) strings; `DateInfo` unmarshals `datetime`/`date` flexibly.

{LenelS2}
- Fix doc comment to reference Lenel S2 API; clarify `CODE` comment in response entity.

{Atlassian}
- Add NewClient()
