### PR TITLE
Change datatype for SnipeIT EOL hardware field

### DIFF
--- a/pkg/snipeit/entities.go
+++ b/pkg/snipeit/entities.go
@@ -226,7 +226,7 @@ type Hardware[M any] struct {
 	Method          M                             `json:",inline"`
 	Model           *Model[GET]                   `json:"model,omitempty"`             // Model of the hardware item.
 	ModelNumber     string                        `json:"model_number,omitempty"`      // Model number of the hardware item.
-	EOL             *Timestamp                    `json:"eol,omitempty"`               // End of life of a hardware item.
+	EOL             string                    `json:"eol,omitempty"`               // End of life of a hardware item.
 	AssetEOLDate    *Timestamp                    `json:"asset_eol_date,omitempty"`    // Asset end of life date of the hardware item.
 	StatusLabel     *StatusLabel                  `json:"status_label,omitempty"`      // Status label of the hardware item.
 	Image           string                        `json:"image,omitempty"`             // Image of the hardware item.


### PR DESCRIPTION
When trying to retrieve all assets, an error is thrown: _"Error fetching hardware list: unmarshalling error: unable to parse date string"_

The EOL datatype is a Timestamp pointer. The hardware struct should be expecting a string for that field instead.